### PR TITLE
Adding snapping to single points

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -210,8 +210,7 @@ const metersPerPixel = function (latitude, zoomLevel) {
 };
 
 // we got the point we want to snap to (C), but we need to check if a coord of the polygon
-// receives priority over C as the snapping point. Let's check this here
-const checkPrioritiySnapping = (closestLayer, snapOptions, snapVertexPriorityDistance = 1.25) => {
+function snapToLineOrPolygon(closestLayer, snapOptions, snapVertexPriorityDistance) {
   // A and B are the points of the closest segment to P (the marker position we want to snap)
   const A = closestLayer.segment[0];
   const B = closestLayer.segment[1];
@@ -258,7 +257,21 @@ const checkPrioritiySnapping = (closestLayer, snapOptions, snapVertexPriorityDis
 
   // return the copy of snapping point
   const [lng, lat] = snapLatlng;
-  return { lng, lat };
+  return {lng, lat};
+}
+
+
+function snapToPoint(closestLayer) {
+  return closestLayer.latlng;
+}
+
+const checkPrioritiySnapping = (closestLayer, snapOptions, snapVertexPriorityDistance = 1.25) => {
+  let snappingToPoint = !Array.isArray(closestLayer.segment);
+  if (snappingToPoint) {
+    return snapToPoint(closestLayer);
+  } else {
+    return snapToLineOrPolygon(closestLayer, snapOptions, snapVertexPriorityDistance);
+  }
 };
 
 /**


### PR DESCRIPTION
## Changes
Currently on the last version there is a bug when trying to snap to points.

<img width="1707" alt="Captura de Pantalla 2022-07-07 a la(s) 15 30 20" src="https://user-images.githubusercontent.com/34402401/177866110-676a23a0-0579-4175-9c6d-7f7de3439099.png">

This is because when we are close to a point, we asume it has to have segments either way.

This pr checks if the closest layer contains segments, and if it doesn't it assumes is a point. So the error is fixed.

## Video
https://user-images.githubusercontent.com/34402401/177865994-96634e1f-51cd-438f-9f1d-de86c01b3762.mp4

